### PR TITLE
Add Delete Account Request page, footer link, sitemap entry, and legal styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
       <p>&copy; 2025 - 2026 Horizon Synergy. All rights reserved.</p>
       <p><a href="legal/privacy-policy.html">Privacy Policy</a></p>
       <p><a href="legal/return-policy.html">Return Policy</a></p>
+      <p><a href="legal/delete-account.html">Delete Account Request</a></p>
       <p><a href="legal/terms-and-conditions.html">Terms & Conditions</a></p>
       <p><a href="https://synergy-network.beehiiv.com/">Synergy Network</a></p>
     </div>

--- a/legal/delete-account.html
+++ b/legal/delete-account.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en-ZA">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <meta name="author" content="Horizon Synergy" />
+  <meta name="theme-color" content="#2f2f2f" />
+  <meta name="google-adsense-account" content="ca-pub-6841184836474681" />
+  <link rel="stylesheet" href="../styles.css" />
+  <link href="https://fonts.cdnfonts.com/css/nasalization" rel="stylesheet" />
+  <link rel="icon" href="../images/hs-logo.png" type="image/png" />
+  <title>Delete Account Request - Horizon Synergy</title>
+  <meta name="description" content="Request deletion of your Horizon Synergy app account and associated data, including account information, saved progress, and support data." />
+  <link rel="canonical" href="https://horizon-synergy.github.io/legal/delete-account.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Horizon Synergy" />
+  <meta property="og:title" content="Delete Account Request - Horizon Synergy" />
+  <meta property="og:description" content="Request deletion of your Horizon Synergy app account and associated data, including account information, saved progress, and support data." />
+  <meta property="og:url" content="https://horizon-synergy.github.io/legal/delete-account.html" />
+  <meta property="og:image" content="https://horizon-synergy.github.io/images/hs-logo.png" />
+  <meta property="og:image:alt" content="Horizon Synergy logo" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Delete Account Request - Horizon Synergy" />
+  <meta name="twitter:description" content="Request deletion of your Horizon Synergy app account and associated data, including account information, saved progress, and support data." />
+  <meta name="twitter:image" content="https://horizon-synergy.github.io/images/hs-logo.png" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Delete Account Request - Horizon Synergy",
+    "url": "https://horizon-synergy.github.io/legal/delete-account.html",
+    "description": "Instructions for requesting deletion of Horizon Synergy app accounts and associated data.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Horizon Synergy",
+      "url": "https://horizon-synergy.github.io/"
+    },
+    "inLanguage": "en-ZA"
+  }
+  </script>
+</head>
+<body class="legal-page">
+  <div class="wave-background" aria-hidden="true">
+    <svg viewBox="0 0 1440 320" preserveAspectRatio="none">
+      <path>
+        <animate attributeName="d" dur="10s" repeatCount="indefinite" values="
+          M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z;
+          M0,180 C480,100 960,300 1440,180 L1440,320 L0,320 Z;
+          M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z" />
+      </path>
+    </svg>
+  </div>
+
+  <main class="legal-main">
+    <article class="legal-document frosted-panel">
+      <header class="legal-hero">
+        <div class="legal-brand-lockup">
+          <img src="../images/hs-logo.png" alt="Horizon Synergy Logo" />
+          <span>Horizon <span class="gradient-text">Synergy</span></span>
+        </div>
+        <p class="hero-tagline">Horizon Synergy Legal</p>
+        <h1>Delete Account Request</h1>
+        <p>Request deletion of your account and associated data for Horizon Synergy apps and games.</p>
+      </header>
+
+      <p class="effective-date"><strong>Effective Date:</strong> June 14, 2026</p>
+
+      <div class="legal-intro">
+        <p>This page explains how users of <strong>Horizon Synergy</strong> apps and games, including <strong>Space Dash</strong> and future titles, can request deletion of their account and associated data. It is intended for use as the Delete Account URL on Google Play Store listings.</p>
+      </div>
+
+      <section>
+        <h2>1. How to Request Account Deletion</h2>
+        <p>To request deletion of your Horizon Synergy app account and associated data, follow these steps:</p>
+        <ol>
+          <li>Email <a href="mailto:horizonsynergyx@gmail.com?subject=Account%20Deletion%20Request%20-%20Horizon%20Synergy">horizonsynergyx@gmail.com</a> with the subject line <strong>Account Deletion Request - Horizon Synergy</strong>.</li>
+          <li>Include the app or game name, such as <strong>Space Dash</strong>, and the email address, username, player ID, or other account identifier connected to your account.</li>
+          <li>If you contacted us from a different email address than the one on your account, include enough information for us to verify that you own the account.</li>
+          <li>We will review your request, may ask for verification, and will confirm when the deletion process has been completed.</li>
+        </ol>
+        <div class="highlight-box">
+          <p><strong>Important:</strong> Deleting your account may permanently remove saved progress, account preferences, and other account-linked information. Deleted account data may not be recoverable.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>2. Data We Delete</h2>
+        <p>When your deletion request is verified and completed, Horizon Synergy will delete or anonymize account data that we control, which may include:</p>
+        <ul>
+          <li>Account identifiers, such as email address, username, display name, player ID, or profile information.</li>
+          <li>Saved game progress, preferences, leaderboard entries, and account-linked gameplay data where supported by the app.</li>
+          <li>Support messages and request details that are no longer needed after the deletion request is completed.</li>
+          <li>App-specific data stored in Horizon Synergy-controlled systems or trusted platforms used to operate the app.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>3. Data We May Keep and Retention Periods</h2>
+        <p>Some information may be retained for a limited period where required for security, legal, fraud-prevention, accounting, dispute-resolution, or backup purposes.</p>
+        <ul>
+          <li><strong>Deletion request records:</strong> We may keep a minimal record of your request and completion status for up to <strong>12 months</strong> to show that we handled the request.</li>
+          <li><strong>Security, crash, and diagnostic logs:</strong> Logs may be retained for up to <strong>90 days</strong> unless a longer period is needed to investigate abuse, security issues, or legal claims.</li>
+          <li><strong>Backups:</strong> Deleted data may remain in encrypted backups for up to <strong>90 days</strong> before those backups are overwritten or expire.</li>
+          <li><strong>Purchase and transaction records:</strong> If applicable, payment, purchase, refund, tax, or accounting records may be retained as required by law or platform rules.</li>
+          <li><strong>Third-party provider data:</strong> Data controlled by platforms such as Google Play, Unity, Firebase, ad networks, or analytics providers is handled under their own policies and may need to be managed through those providers.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>4. Processing Time</h2>
+        <p>We aim to complete verified account deletion requests within <strong>30 days</strong>. If a request is complex, we will contact you and explain any expected delay.</p>
+      </section>
+
+      <section>
+        <h2>5. If You Do Not Have an Account</h2>
+        <p>Some Horizon Synergy apps or games may not require user accounts. If an app does not have account functionality, email us with the app name and any identifiers you can provide, and we will help identify whether we hold data that can be deleted.</p>
+      </section>
+
+      <section class="contact-box">
+        <h2>6. Contact</h2>
+        <p>For account deletion requests or privacy questions, contact Horizon Synergy at <a href="mailto:horizonsynergyx@gmail.com">horizonsynergyx@gmail.com</a>.</p>
+      </section>
+
+      <footer class="legal-footer">
+        <p><strong>Horizon Synergy</strong> – Creations Of Tomorrow</p>
+        <p>&copy; 2025 - 2026 Horizon Synergy. All rights reserved.</p>
+      </footer>
+    </article>
+  </main>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -24,4 +24,10 @@
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://horizon-synergy.github.io/legal/delete-account.html</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/styles.css
+++ b/styles.css
@@ -1614,7 +1614,8 @@ body.legal-page main section h3 {
   color: var(--accent-color);
 }
 
-body.legal-page main section ul {
+body.legal-page main section ul,
+body.legal-page main section ol {
   margin: 0.8rem 0 0.8rem 1.35rem;
 }
 


### PR DESCRIPTION
### Motivation

- Provide a dedicated Delete Account Request page to serve as the Delete Account URL for app store listings and to document how users can request account/data deletion.  
- Surface the new page from the site footer so visitors and store reviewers can easily find the deletion instructions.  
- Ensure the new legal content is discoverable by search engines via the sitemap and is styled consistently with other legal pages.

### Description

- Added a new legal page `legal/delete-account.html` containing instructions, retention details, contact info, metadata, and structured data for account deletion requests.  
- Updated `index.html` to add a footer link to `legal/delete-account.html`.  
- Updated `sitemap.xml` to include the new `https://horizon-synergy.github.io/legal/delete-account.html` entry with `lastmod` set to `2026-06-14`.  
- Adjusted `styles.css` to include `ol` styling under `.legal-page` so ordered lists in legal documents match existing list formatting.

### Testing

- No automated tests were run for these static content and stylesheet changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f1cb30efc832cb65f16b306defd37)