### PR TITLE
Add Ventures hub, legal pages, cookie consent, and sitemap updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,8 @@
     <hr>
     <a href="#products" id="page-links">Products</a>
     <hr>
+    <a href="ventures/" id="page-links">Ventures</a>
+    <hr>
     <a href="#contact" id="page-links">Contact Us</a>
 
     <div class="search-panel">
@@ -174,9 +176,12 @@
 
     <div class="footer-part" id="footer-part">
       <p>&copy; 2025 - 2026 Horizon Synergy. All rights reserved.</p>
+      <p><a href="ventures/">Ventures</a></p>
       <p><a href="legal/privacy-policy.html">Privacy Policy</a></p>
+      <p><a href="legal/cookie-policy.html">Cookie Policy</a></p>
       <p><a href="legal/return-policy.html">Return Policy</a></p>
-      <p><a href="legal/terms-and-conditions.html">Terms & Conditions</a></p>
+      <p><a href="legal/terms-of-service.html">Terms of Service</a></p>
+      <p><a href="legal/accessibility.html">Accessibility</a></p>
       <p><a href="https://synergy-network.beehiiv.com/">Synergy Network</a></p>
     </div>
 
@@ -192,6 +197,9 @@
         <p class="hero-brand-signal">Looking for <strong>Horizon Synergy</strong> or <strong>Horizon Synergy South
             Africa</strong>? You're in the right place.</p>
         <div class="hero-actions">
+          <a href="ventures/" class="hero-cta secondary">
+            Explore Ventures
+          </a>
           <a href="#products" class="hero-cta primary"
             onclick="event.preventDefault(); showSection('products'); document.getElementById('sidebar').classList.remove('show');">
             Explore Products

--- a/legal/accessibility.html
+++ b/legal/accessibility.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en-ZA">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="index, follow" />
+  <meta name="author" content="Horizon Synergy" />
+  <link rel="stylesheet" href="../styles.css" />
+  <link rel="icon" href="../images/hs-logo.png" type="image/png" />
+  <title>Accessibility Statement - Horizon Synergy</title>
+  <meta name="description" content="Horizon Synergy's accessibility statement and contact route for accessibility feedback." />
+  <link rel="canonical" href="https://horizon-synergy.github.io/legal/accessibility.html" />
+  <script src="../main.js" defer></script>
+</head>
+<body class="legal-page">
+  <main class="legal-main">
+    <article class="legal-document frosted-panel">
+      <header class="legal-hero">
+        <div class="legal-brand-lockup"><img src="../images/hs-logo.png" alt="Horizon Synergy Logo" /><span>Horizon <span class="gradient-text">Synergy</span></span></div>
+        <p class="hero-tagline">Horizon Synergy Legal</p>
+        <a class="legal-home-link" href="../index.html">Back to Main Site</a>
+        <h1>Accessibility Statement</h1>
+        <p>We want Horizon Synergy websites and products to be usable by as many people as possible.</p>
+      </header>
+      <p class="effective-date"><strong>Effective Date:</strong> July 17, 2026</p>
+      <section><h2>Our Commitment</h2><p>We aim to improve readability, keyboard access, responsive layouts, clear labels, and helpful contrast across our digital experiences.</p></section>
+      <section><h2>Ongoing Improvements</h2><p>Accessibility is an ongoing process. As our products evolve, we will continue improving page structure, alt text, focus states, and compatibility with assistive technologies.</p></section>
+      <section class="contact-box"><h2>Feedback</h2><p>If you find an accessibility barrier, email <a href="mailto:horizonsynergyx@gmail.com">horizonsynergyx@gmail.com</a> with the page URL and a short description of the issue.</p></section>
+      <footer class="legal-footer"><p><strong>Horizon Synergy</strong> - Creations Of Tomorrow</p><p>&copy; 2025 - 2026 Horizon Synergy. All rights reserved.</p></footer>
+    </article>
+  </main>
+</body>
+</html>

--- a/legal/cookie-policy.html
+++ b/legal/cookie-policy.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en-ZA">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <meta name="author" content="Horizon Synergy" />
+  <meta name="theme-color" content="#2f2f2f" />
+  <link rel="stylesheet" href="../styles.css" />
+  <link rel="icon" href="../images/hs-logo.png" type="image/png" />
+  <title>Cookie Policy - Horizon Synergy</title>
+  <meta name="description" content="How Horizon Synergy uses cookies, local storage, analytics, embeds, and consent preferences across our website." />
+  <link rel="canonical" href="https://horizon-synergy.github.io/legal/cookie-policy.html" />
+  <script src="../main.js" defer></script>
+</head>
+<body class="legal-page">
+  <div class="wave-background" aria-hidden="true"><svg viewBox="0 0 1440 320" preserveAspectRatio="none"><path><animate attributeName="d" dur="10s" repeatCount="indefinite" values="M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z;M0,180 C480,100 960,300 1440,180 L1440,320 L0,320 Z;M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z" /></path></svg></div>
+  <main class="legal-main">
+    <article class="legal-document frosted-panel">
+      <header class="legal-hero"><div class="legal-brand-lockup"><img src="../images/hs-logo.png" alt="Horizon Synergy Logo" /><span>Horizon <span class="gradient-text">Synergy</span></span></div><p class="hero-tagline">Horizon Synergy Legal</p><a class="legal-home-link" href="../index.html">Back to Main Site</a><h1>Cookie Policy</h1><p>How we use cookies, local storage, analytics, and embedded services.</p></header>
+      <p class="effective-date"><strong>Effective Date:</strong> July 17, 2026</p>
+      <div class="legal-intro"><p>We use a small cookie consent tool and browser storage to remember your preferences. Some third-party services may also use cookies or similar technologies.</p></div>
+      <section><h2>1. What We Use</h2><ul><li><strong>Essential storage:</strong> remembers your theme and cookie choice.</li><li><strong>Analytics and advertising:</strong> services such as Google Analytics, Google AdSense, and embedded scripts may measure traffic or support ads when enabled.</li><li><strong>Forms and embeds:</strong> third-party forms or widgets may set cookies needed for security, spam prevention, or functionality.</li></ul></section>
+      <section><h2>2. Your Choice</h2><p>You can accept or decline non-essential cookies using the banner on this site. Essential preferences may still be stored so the site can remember your choice.</p><button class="download-link" type="button" onclick="resetCookieConsent()">Reset Cookie Choice</button></section>
+      <section><h2>3. Managing Cookies in Your Browser</h2><p>You can also delete or block cookies in your browser settings. Blocking some cookies may affect embedded forms, analytics, ads, or third-party features.</p></section>
+      <section><h2>4. Related Policies</h2><p>For more information about data handling, read our <a href="privacy-policy.html">Privacy Policy</a> and <a href="terms-of-service.html">Terms of Service</a>.</p></section>
+      <section class="contact-box"><h2>5. Contact</h2><p>Email <a href="mailto:horizonsynergyx@gmail.com">horizonsynergyx@gmail.com</a> with cookie or privacy questions.</p></section>
+      <footer class="legal-footer"><p><strong>Horizon Synergy</strong> - Creations Of Tomorrow</p><p>&copy; 2025 - 2026 Horizon Synergy. All rights reserved.</p></footer>
+    </article>
+  </main>
+</body>
+</html>

--- a/legal/privacy-policy.html
+++ b/legal/privacy-policy.html
@@ -46,6 +46,7 @@
     "inLanguage": "en-ZA"
   }
   </script>
+  <script src="../main.js" defer></script>
 </head>
 <body class="legal-page">
   <div class="wave-background" aria-hidden="true">

--- a/legal/return-policy.html
+++ b/legal/return-policy.html
@@ -55,6 +55,7 @@
     ]
   }
   </script>
+  <script src="../main.js" defer></script>
 </head>
 <body class="legal-page">
   <div class="wave-background" aria-hidden="true">

--- a/legal/terms-and-conditions.html
+++ b/legal/terms-and-conditions.html
@@ -47,6 +47,7 @@
     "inLanguage": "en-ZA"
   }
   </script>
+  <script src="../main.js" defer></script>
 </head>
 <body class="legal-page">
   <div class="wave-background" aria-hidden="true">

--- a/legal/terms-of-service.html
+++ b/legal/terms-of-service.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en-ZA">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <meta name="author" content="Horizon Synergy" />
+  <meta name="theme-color" content="#2f2f2f" />
+  <link rel="stylesheet" href="../styles.css" />
+  <link rel="icon" href="../images/hs-logo.png" type="image/png" />
+  <title>Terms of Service - Horizon Synergy</title>
+  <meta name="description" content="The Terms of Service for using Horizon Synergy websites, apps, games, ventures, and digital services." />
+  <link rel="canonical" href="https://horizon-synergy.github.io/legal/terms-of-service.html" />
+  <script src="../main.js" defer></script>
+</head>
+<body class="legal-page">
+  <div class="wave-background" aria-hidden="true"><svg viewBox="0 0 1440 320" preserveAspectRatio="none"><path><animate attributeName="d" dur="10s" repeatCount="indefinite" values="M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z;M0,180 C480,100 960,300 1440,180 L1440,320 L0,320 Z;M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z" /></path></svg></div>
+  <main class="legal-main">
+    <article class="legal-document frosted-panel">
+      <header class="legal-hero">
+        <div class="legal-brand-lockup"><img src="../images/hs-logo.png" alt="Horizon Synergy Logo" /><span>Horizon <span class="gradient-text">Synergy</span></span></div>
+        <p class="hero-tagline">Horizon Synergy Legal</p>
+        <a class="legal-home-link" href="../index.html">Back to Main Site</a>
+        <h1>Terms of Service</h1>
+        <p>The agreement for using our websites, apps, games, ventures, and digital services.</p>
+      </header>
+      <p class="effective-date"><strong>Effective Date:</strong> July 17, 2026</p>
+      <div class="legal-intro"><p>By accessing Horizon Synergy services, you agree to use them responsibly and follow these Terms of Service. If you do not agree, please do not use our services.</p></div>
+      <section><h2>1. Services Covered</h2><p>These terms apply to Horizon Synergy websites, legal pages, games, apps, ventures, experiments, contact forms, and related digital experiences unless a product-specific agreement says otherwise.</p></section>
+      <section><h2>2. Acceptable Use</h2><ul><li>Do not misuse, reverse engineer, attack, scrape, or disrupt our services.</li><li>Do not upload harmful, unlawful, misleading, infringing, or abusive content.</li><li>Do not impersonate Horizon Synergy, our team, or other users.</li><li>Use our products only in ways permitted by applicable law and platform rules.</li></ul></section>
+      <section><h2>3. Accounts and Product Access</h2><p>Some products may require accounts or third-party platform access. You are responsible for keeping your login information safe and for activity under your account.</p></section>
+      <section><h2>4. Intellectual Property</h2><p>Horizon Synergy names, logos, designs, code, content, product concepts, and assets belong to Horizon Synergy or our licensors. You may not copy or reuse them without permission, except where open-source licenses or platform rules allow it.</p></section>
+      <section><h2>5. Purchases, Refunds, and Third Parties</h2><p>Purchases made through app stores, marketplaces, payment providers, or partner platforms may be governed by those providers' own terms. For eligible physical products, review our <a href="return-policy.html">Return Policy</a>.</p></section>
+      <section><h2>6. Disclaimers</h2><p>Our services are provided “as is” and may change, pause, or end. We work to keep services reliable, but we cannot guarantee uninterrupted access, error-free operation, or suitability for every purpose.</p></section>
+      <section><h2>7. Limitation of Liability</h2><p>To the fullest extent allowed by law, Horizon Synergy will not be liable for indirect, incidental, special, consequential, or punitive damages arising from your use of our services.</p></section>
+      <section><h2>8. Updates</h2><p>We may update these terms when our services, laws, or operations change. Continued use after updates means you accept the revised terms.</p></section>
+      <section class="contact-box"><h2>9. Contact</h2><p>Questions about these terms? Email <a href="mailto:horizonsynergyx@gmail.com">horizonsynergyx@gmail.com</a>.</p></section>
+      <footer class="legal-footer"><p><strong>Horizon Synergy</strong> - Creations Of Tomorrow</p><p>&copy; 2025 - 2026 Horizon Synergy. All rights reserved.</p></footer>
+    </article>
+  </main>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -111,3 +111,48 @@ document.addEventListener('click', (event) => {
     sidebar.classList.remove('show');
   }
 });
+
+function applyCookieConsent(choice) {
+  localStorage.setItem("cookieConsent", choice);
+  const banner = document.getElementById("cookie-banner");
+  if (banner) {
+    banner.remove();
+  }
+}
+
+function resetCookieConsent() {
+  localStorage.removeItem("cookieConsent");
+  showCookieBanner(true);
+}
+
+function showCookieBanner(force = false) {
+  if (!force && localStorage.getItem("cookieConsent")) {
+    return;
+  }
+
+  const existing = document.getElementById("cookie-banner");
+  if (existing) {
+    existing.remove();
+  }
+
+  const banner = document.createElement("div");
+  banner.id = "cookie-banner";
+  banner.className = "cookie-banner";
+  banner.setAttribute("role", "dialog");
+  banner.setAttribute("aria-live", "polite");
+  banner.setAttribute("aria-label", "Cookie consent");
+  banner.innerHTML = `
+    <p><strong>Cookies & privacy:</strong> We use essential storage for preferences and may use analytics, ads, or embedded services. Read our <a href="/legal/cookie-policy.html">Cookie Policy</a>.</p>
+    <div class="cookie-actions">
+      <button class="accept-cookies" type="button">Accept</button>
+      <button class="decline-cookies" type="button">Decline non-essential</button>
+    </div>
+  `;
+  document.body.appendChild(banner);
+  banner.querySelector(".accept-cookies").addEventListener("click", () => applyCookieConsent("accepted"));
+  banner.querySelector(".decline-cookies").addEventListener("click", () => applyCookieConsent("declined"));
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  showCookieBanner();
+});

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,27 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://horizon-synergy.github.io/</loc>
-    <lastmod>2026-06-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://horizon-synergy.github.io/legal/privacy-policy.html</loc>
-    <lastmod>2026-06-30</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://horizon-synergy.github.io/legal/terms-and-conditions.html</loc>
-    <lastmod>2026-06-30</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://horizon-synergy.github.io/legal/return-policy.html</loc>
-    <lastmod>2026-06-30</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.6</priority>
-  </url>
+  <url><loc>https://horizon-synergy.github.io/</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://horizon-synergy.github.io/ventures/</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://horizon-synergy.github.io/legal/privacy-policy.html</loc><lastmod>2026-06-30</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://horizon-synergy.github.io/legal/terms-of-service.html</loc><lastmod>2026-07-17</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://horizon-synergy.github.io/legal/cookie-policy.html</loc><lastmod>2026-07-17</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://horizon-synergy.github.io/legal/accessibility.html</loc><lastmod>2026-07-17</lastmod><changefreq>yearly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://horizon-synergy.github.io/legal/terms-and-conditions.html</loc><lastmod>2026-06-30</lastmod><changefreq>yearly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://horizon-synergy.github.io/legal/return-policy.html</loc><lastmod>2026-06-30</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/styles.css
+++ b/styles.css
@@ -1684,3 +1684,174 @@ body.light-mode.legal-page .legal-hero h1 {
     border-radius: 26px;
   }
 }
+
+/* Ventures page and cookie consent additions */
+body.ventures-page {
+  display: block;
+  min-height: 100vh;
+}
+
+.ventures-main {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0 72px;
+}
+
+.ventures-main section {
+  display: block;
+  opacity: 1;
+  transform: none;
+  max-width: none;
+}
+
+.ventures-hero {
+  padding: clamp(2rem, 5vw, 5rem);
+  border-radius: clamp(28px, 4vw, 48px);
+  text-align: center;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.045)),
+    radial-gradient(circle at 50% 0%, rgba(0, 194, 255, 0.2), transparent 42%);
+}
+
+.ventures-hero h1 {
+  max-width: 900px;
+  margin: 1rem auto;
+  font-size: clamp(3rem, 7vw, 6.25rem);
+  line-height: 0.96;
+  letter-spacing: -0.07em;
+}
+
+.ventures-hero p:not(.hero-tagline),
+.venture-process p,
+.venture-card p {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.ventures-section-heading {
+  margin: 4rem 0 1.5rem;
+  text-align: center;
+}
+
+.ventures-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.venture-card {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 1.4rem;
+  padding: 1.5rem;
+  border-radius: 30px;
+}
+
+.venture-card img {
+  width: 110px;
+  height: 110px;
+  object-fit: cover;
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+}
+
+.venture-status {
+  color: var(--accent-color);
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.venture-card h3,
+.venture-process h3 {
+  color: #ffffff;
+}
+
+.venture-process {
+  margin-top: 1.25rem;
+  padding: 2rem;
+  border-radius: 30px;
+  text-align: center;
+}
+
+.process-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.process-grid div {
+  padding: 1.2rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.process-grid strong {
+  color: var(--primary-color);
+}
+
+.cookie-banner {
+  position: fixed;
+  inset: auto 24px 24px auto;
+  z-index: 2000;
+  width: min(430px, calc(100% - 32px));
+  padding: 1rem;
+  border-radius: 22px;
+  background: rgba(12, 12, 16, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(22px) saturate(150%);
+  -webkit-backdrop-filter: blur(22px) saturate(150%);
+}
+
+.cookie-banner p {
+  margin: 0 0 0.9rem;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.55;
+}
+
+.cookie-banner a {
+  color: var(--primary-color);
+}
+
+.cookie-actions {
+  display: flex;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.cookie-actions button {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.cookie-actions .accept-cookies {
+  background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
+  color: #000;
+}
+
+.cookie-actions .decline-cookies {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+@media (max-width: 820px) {
+  .ventures-grid,
+  .process-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .venture-card {
+    grid-template-columns: 1fr;
+  }
+
+  .cookie-banner {
+    inset: auto 16px 16px 16px;
+    width: auto;
+  }
+}

--- a/ventures/index.html
+++ b/ventures/index.html
@@ -1,17 +1,106 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-ZA">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Horizon Synergy | Ventures</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="author" content="Horizon Synergy">
+  <meta name="theme-color" content="#000000">
+  <title>Horizon Synergy Ventures | Startup Products, Apps & Experiments</title>
+  <meta name="description" content="Explore Horizon Synergy Ventures: focused product lines, startup experiments, and emerging digital businesses including StudX and Vaia.">
+  <link rel="canonical" href="https://horizon-synergy.github.io/ventures/">
+  <link rel="stylesheet" href="../styles.css">
+  <link href="https://fonts.cdnfonts.com/css/nasalization" rel="stylesheet">
+  <link rel="icon" href="../images/hs-logo.png" type="image/png">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Horizon Synergy">
+  <meta property="og:title" content="Horizon Synergy Ventures">
+  <meta property="og:description" content="Focused startup ventures, product lines, and experiments from Horizon Synergy.">
+  <meta property="og:url" content="https://horizon-synergy.github.io/ventures/">
+  <meta property="og:image" content="https://horizon-synergy.github.io/images/hs-logo.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Horizon Synergy Ventures",
+    "url": "https://horizon-synergy.github.io/ventures/",
+    "description": "A directory of Horizon Synergy ventures, startup experiments, and focused product lines.",
+    "publisher": {"@type": "Organization", "name": "Horizon Synergy", "url": "https://horizon-synergy.github.io/"},
+    "inLanguage": "en-ZA"
+  }
+  </script>
+  <script src="https://kit.fontawesome.com/c487386ab7.js" crossorigin="anonymous"></script>
+  <script src="../main.js" defer></script>
 </head>
-<body>
-    <div>
-        <h1>Horizon Synergy Ventures</h1>
-        <p>Welcome to our ventures page!</p>
+<body class="ventures-page">
+  <div class="wave-background" aria-hidden="true">
+    <svg viewBox="0 0 1440 320" preserveAspectRatio="none"><path><animate attributeName="d" dur="10s" repeatCount="indefinite" values="M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z;M0,180 C480,100 960,300 1440,180 L1440,320 L0,320 Z;M0,160 C480,300 960,20 1440,160 L1440,320 L0,320 Z" /></path></svg>
+  </div>
 
-        <a href="studx.html">StudX</a>
-        <a href="vaia.html">Vaia</a>
-    </div>
+  <main class="ventures-main">
+    <section class="ventures-hero frosted-panel">
+      <a class="legal-home-link" href="../index.html">← Back to Main Site</a>
+      <div class="legal-brand-lockup">
+        <img src="../images/hs-logo.png" alt="Horizon Synergy Logo">
+        <span>Horizon <span class="gradient-text">Synergy</span></span>
+      </div>
+      <p class="hero-tagline">Venture Studio</p>
+      <h1>Ideas we are turning into focused ventures.</h1>
+      <p>Horizon Synergy Ventures is where our standalone businesses, experimental products, and student-focused platforms get room to grow. Each venture starts small, solves a clear problem, and is built to become useful beyond the first launch.</p>
+      <div class="hero-actions">
+        <a class="hero-cta primary" href="#venture-list">Explore Ventures <span>→</span></a>
+        <a class="hero-cta secondary" href="../index.html#contact">Partner With Us</a>
+      </div>
+    </section>
+
+    <section id="venture-list" class="ventures-grid-section">
+      <div class="ventures-section-heading">
+        <p class="hero-tagline">Active Ventures</p>
+        <h2>Built under the Horizon Synergy umbrella</h2>
+      </div>
+
+      <div class="ventures-grid">
+        <article class="venture-card frosted-panel">
+          <img src="../images/studx.png" alt="StudX logo">
+          <div>
+            <span class="venture-status">Live / Early growth</span>
+            <h3>StudX</h3>
+            <p>A student marketplace designed to help campus communities buy, sell, discover opportunities, and build stronger peer networks.</p>
+            <div class="app-features">
+              <span class="feature-badge"><i class="fa-solid fa-store"></i> Marketplace</span>
+              <span class="feature-badge"><i class="fa-solid fa-graduation-cap"></i> Students</span>
+              <span class="feature-badge"><i class="fa-solid fa-mobile-screen"></i> Web + Android</span>
+            </div>
+            <a class="download-link" href="studx.html">View Venture</a>
+          </div>
+        </article>
+
+        <article class="venture-card frosted-panel">
+          <img src="../images/neo.jpeg" alt="Vaia visual identity">
+          <div>
+            <span class="venture-status">Concept / validation</span>
+            <h3>Vaia</h3>
+            <p>An emerging Horizon Synergy venture exploring practical digital assistance, smarter workflows, and future-ready productivity experiences.</p>
+            <div class="app-features">
+              <span class="feature-badge"><i class="fa-solid fa-sparkles"></i> Emerging tech</span>
+              <span class="feature-badge"><i class="fa-solid fa-rocket"></i> Prototype</span>
+              <span class="feature-badge"><i class="fa-solid fa-diagram-project"></i> Venture lab</span>
+            </div>
+            <a class="download-link" href="vaia.html">View Venture</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="venture-process frosted-panel">
+      <p class="hero-tagline">How We Build</p>
+      <h2>Small launches. Real feedback. Better products.</h2>
+      <div class="process-grid">
+        <div><strong>01</strong><h3>Validate</h3><p>We test whether a problem is real before scaling the solution.</p></div>
+        <div><strong>02</strong><h3>Launch</h3><p>We ship lean, useful versions that people can actually try.</p></div>
+        <div><strong>03</strong><h3>Grow</h3><p>We improve with feedback, partnerships, and sustainable operations.</p></div>
+      </div>
+    </section>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a polished Ventures hub to surface product lines and experiments and make them discoverable from the main site.
- Add missing legal pages (Terms of Service, Cookie Policy, Accessibility) so visitors can review key policies and opt-out options.
- Implement a simple cookie consent mechanism and expose links to the new legal pages from the site navigation and footer.

### Description
- Added a new venture-studio landing page at `ventures/index.html` with SEO metadata, structured data (JSON-LD), hero, venture cards for StudX and Vaia, and a short build process section.
- Added legal pages `legal/terms-of-service.html`, `legal/cookie-policy.html`, and `legal/accessibility.html`, and wired a cookie policy link into the footer and sidebar in `index.html`.
- Implemented a client-side cookie consent banner using `localStorage` and functions `showCookieBanner`, `applyCookieConsent`, and `resetCookieConsent` in `main.js`, and added supportive styles to `styles.css` for the ventures layout and cookie banner.
- Updated `sitemap.xml` to include the new `ventures/` and legal pages and added `main.js` references to existing legal pages where needed for the cookie/reset functionality.

### Testing
- Ran `git diff --check` to verify there were no whitespace or diff issues and it completed successfully.
- Performed a lightweight HTML parser smoke check using `python3` with `html.parser` on updated and newly added HTML files, and all files parsed without errors.
- Visual/manual screenshot testing was skipped because no browser executable was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a700d9b40832c8f005611d656a1c2)