### PR TITLE
Add glassmorphism organisational chart and animations to team page

### DIFF
--- a/team/index.html
+++ b/team/index.html
@@ -17,39 +17,60 @@
     :root {
       --primary: #0099ff;
       --accent: #00a976;
-      --bg: #2f2f2f;
+      --bg: #1f2428;
       --text: #eef4ed;
-      --muted: rgba(238, 244, 237, 0.72);
-      --line: rgba(0, 153, 255, 0.2);
-      --panel: rgba(238, 244, 237, 0.06);
+      --muted: rgba(238, 244, 237, 0.74);
+      --line: rgba(178, 229, 255, 0.26);
+      --panel: rgba(255, 255, 255, 0.075);
+      --glass-edge: rgba(255, 255, 255, 0.42);
+      --glass-shadow: rgba(0, 0, 0, 0.28);
     }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
+    html { scroll-behavior: smooth; }
+
     body {
       min-height: 100vh;
+      overflow-x: hidden;
       font-family: "Google Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       background:
-        radial-gradient(circle at 12% 10%, rgba(0, 153, 255, 0.22), transparent 34rem),
-        radial-gradient(circle at 88% 12%, rgba(0, 169, 118, 0.16), transparent 30rem),
-        var(--bg);
+        radial-gradient(circle at 16% 8%, rgba(0, 153, 255, 0.36), transparent 28rem),
+        radial-gradient(circle at 88% 18%, rgba(0, 169, 118, 0.24), transparent 26rem),
+        radial-gradient(circle at 48% 100%, rgba(166, 219, 255, 0.13), transparent 30rem),
+        linear-gradient(135deg, #15191d 0%, #2f2f2f 48%, #172a30 100%);
       color: var(--text);
     }
 
-    body::before {
+    body::before,
+    body::after {
       content: "";
       position: fixed;
       inset: 0;
       pointer-events: none;
-      background-image: linear-gradient(rgba(238, 244, 237, 0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(238, 244, 237, 0.035) 1px, transparent 1px);
+    }
+
+    body::before {
+      background-image:
+        linear-gradient(rgba(238, 244, 237, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(238, 244, 237, 0.04) 1px, transparent 1px);
       background-size: 48px 48px;
-      mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent 82%);
+      mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.82), transparent 84%);
+    }
+
+    body::after {
+      background:
+        radial-gradient(circle at var(--mx, 50%) var(--my, 20%), rgba(255, 255, 255, 0.14), transparent 18rem),
+        linear-gradient(115deg, transparent 0 40%, rgba(255, 255, 255, 0.055) 48%, transparent 56% 100%);
+      mix-blend-mode: screen;
+      opacity: 0.8;
+      animation: ambientRefraction 14s ease-in-out infinite alternate;
     }
 
     a { color: inherit; }
 
     .page-shell {
-      width: min(1120px, calc(100% - 32px));
+      width: min(1160px, calc(100% - 32px));
       margin: 0 auto;
       position: relative;
       z-index: 1;
@@ -61,6 +82,7 @@
       justify-content: space-between;
       gap: 1rem;
       padding: 1.25rem 0;
+      animation: floatIn 0.75s ease both;
     }
 
     .brand {
@@ -77,13 +99,13 @@
       width: 48px;
       height: 48px;
       border-radius: 50%;
-      border: 2px solid var(--primary);
-      box-shadow: 0 0 28px rgba(0, 153, 255, 0.3);
+      border: 2px solid var(--glass-edge);
+      box-shadow: 0 0 28px rgba(0, 153, 255, 0.3), inset 0 0 18px rgba(255, 255, 255, 0.22);
     }
 
     .brand span span,
     .gradient-text {
-      background: linear-gradient(135deg, var(--primary), var(--accent));
+      background: linear-gradient(135deg, #7ad4ff, var(--primary), #6effcf, var(--accent));
       -webkit-background-clip: text;
       background-clip: text;
       -webkit-text-fill-color: transparent;
@@ -98,32 +120,50 @@
     }
 
     nav a,
-    .button {
+    .button,
+    .glass-panel,
+    .team-card {
+      position: relative;
       border: 1px solid var(--line);
+      background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.055)),
+        radial-gradient(circle at 18% 0%, rgba(255, 255, 255, 0.22), transparent 28%),
+        var(--panel);
+      backdrop-filter: blur(22px) saturate(160%);
+      -webkit-backdrop-filter: blur(22px) saturate(160%);
+      box-shadow:
+        0 30px 90px var(--glass-shadow),
+        inset 0 1px 0 rgba(255, 255, 255, 0.34),
+        inset 0 -18px 42px rgba(0, 153, 255, 0.045);
+    }
+
+    nav a,
+    .button {
       border-radius: 999px;
       padding: 0.8rem 1.05rem;
       text-decoration: none;
       color: var(--text);
       font-weight: 800;
-      background: rgba(47, 47, 47, 0.58);
-      backdrop-filter: blur(12px);
+      overflow: hidden;
       transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
     nav a:hover,
-    .button:hover {
-      transform: translateY(-2px);
-      border-color: rgba(0, 153, 255, 0.62);
-      box-shadow: 0 12px 36px rgba(0, 153, 255, 0.16);
+    .button:hover,
+    .team-card:hover {
+      transform: translateY(-4px);
+      border-color: rgba(151, 222, 255, 0.68);
+      box-shadow: 0 28px 80px rgba(0, 153, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.45);
     }
 
     .hero {
-      padding: clamp(3rem, 8vw, 6rem) 0 3rem;
+      padding: clamp(3rem, 8vw, 6rem) 0 2rem;
       text-align: center;
+      animation: floatIn 0.9s 0.08s ease both;
     }
 
     .eyebrow {
-      color: var(--accent);
+      color: #6effcf;
       font-size: 0.9rem;
       font-weight: 900;
       letter-spacing: 0.22em;
@@ -147,41 +187,98 @@
       line-height: 1.75;
     }
 
-    .team-grid {
+    .org-chart {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 1.25rem;
+      gap: 2.5rem;
       padding: 2rem 0 4rem;
+    }
+
+    .org-tier {
+      display: grid;
+      justify-items: center;
+      position: relative;
+    }
+
+    .org-tier.executive::after {
+      content: "";
+      width: 2px;
+      height: 3rem;
+      margin-top: 1rem;
+      background: linear-gradient(to bottom, rgba(122, 212, 255, 0.9), rgba(110, 255, 207, 0.25));
+      filter: drop-shadow(0 0 10px rgba(0, 153, 255, 0.55));
+      animation: pulseLine 2.8s ease-in-out infinite;
+    }
+
+    .org-branch {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      justify-items: center;
+      gap: 1.25rem;
+      position: relative;
+    }
+
+    .org-branch::before {
+      content: "";
+      position: absolute;
+      top: -1.5rem;
+      left: 25%;
+      right: 25%;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, rgba(122, 212, 255, 0.86), rgba(110, 255, 207, 0.72), transparent);
+      filter: drop-shadow(0 0 10px rgba(0, 153, 255, 0.55));
     }
 
     .team-card {
       overflow: hidden;
-      border: 1px solid var(--line);
-      border-radius: 30px;
-      background: linear-gradient(145deg, rgba(238, 244, 237, 0.09), var(--panel));
-      box-shadow: 0 30px 90px rgba(0, 0, 0, 0.22);
+      border-radius: 34px;
+      isolation: isolate;
+      animation: floatIn 0.9s ease both, glassDrift 7s ease-in-out infinite;
+      transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+    }
+
+    .team-card.featured {
+      width: min(620px, 100%);
+    }
+
+    .org-branch .team-card {
+      width: min(560px, 100%);
+    }
+
+    .team-card:nth-child(2) { animation-delay: 0.12s, 0.7s; }
+
+    .team-card::before {
+      content: "";
+      position: absolute;
+      inset: -1px;
+      z-index: -1;
+      background:
+        linear-gradient(120deg, transparent 20%, rgba(255, 255, 255, 0.38), transparent 48%),
+        radial-gradient(circle at 80% 10%, rgba(110, 255, 207, 0.16), transparent 30%);
+      transform: translateX(-55%);
+      animation: shimmer 5.6s ease-in-out infinite;
     }
 
     .portrait-wrap {
-      min-height: 340px;
-      background: linear-gradient(135deg, rgba(0, 153, 255, 0.22), rgba(0, 169, 118, 0.12));
+      min-height: 300px;
+      background:
+        radial-gradient(circle at 45% 34%, rgba(255, 255, 255, 0.22), transparent 18%),
+        linear-gradient(135deg, rgba(0, 153, 255, 0.28), rgba(0, 169, 118, 0.14));
       display: grid;
       place-items: center;
       padding: 2rem;
     }
 
     .portrait-wrap img {
-      width: min(260px, 76vw);
+      width: min(240px, 70vw);
       aspect-ratio: 1;
       object-fit: cover;
       border-radius: 50%;
       border: 4px solid rgba(238, 244, 237, 0.82);
-      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32), inset 0 0 28px rgba(255, 255, 255, 0.28);
+      animation: portraitFloat 5.5s ease-in-out infinite;
     }
 
-    .card-body {
-      padding: clamp(1.4rem, 4vw, 2rem);
-    }
+    .card-body { padding: clamp(1.4rem, 4vw, 2rem); }
 
     .role {
       display: inline-flex;
@@ -192,6 +289,7 @@
       color: #62ffc9;
       font-weight: 900;
       font-size: 0.86rem;
+      border: 1px solid rgba(110, 255, 207, 0.24);
     }
 
     h2 {
@@ -202,33 +300,18 @@
       margin-bottom: 1rem;
     }
 
-    .card-body p {
-      color: var(--muted);
-      line-height: 1.7;
-      margin-bottom: 1.2rem;
-    }
+    .card-body p { color: var(--muted); line-height: 1.7; margin-bottom: 1.2rem; }
 
-    .focus-list {
-      display: grid;
-      gap: 0.6rem;
-      margin: 1.2rem 0;
-      color: var(--muted);
-      list-style: none;
-    }
+    .focus-list { display: grid; gap: 0.6rem; margin: 1.2rem 0; color: var(--muted); list-style: none; }
 
     .focus-list li {
       padding: 0.7rem 0.85rem;
-      border: 1px solid rgba(238, 244, 237, 0.1);
+      border: 1px solid rgba(238, 244, 237, 0.12);
       border-radius: 16px;
-      background: rgba(238, 244, 237, 0.04);
+      background: rgba(238, 244, 237, 0.055);
     }
 
-    .social-links {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.7rem;
-      margin-top: 1.4rem;
-    }
+    .social-links { display: flex; flex-wrap: wrap; gap: 0.7rem; margin-top: 1.4rem; }
 
     .social-links a {
       text-decoration: none;
@@ -237,31 +320,30 @@
       border-radius: 999px;
       padding: 0.65rem 0.85rem;
       background: rgba(0, 153, 255, 0.08);
+      transition: background 0.2s ease, transform 0.2s ease;
     }
 
-    .social-links a:hover {
-      background: rgba(0, 153, 255, 0.16);
-    }
+    .social-links a:hover { background: rgba(0, 153, 255, 0.16); transform: translateY(-2px); }
 
-    footer {
-      color: rgba(238, 244, 237, 0.55);
-      text-align: center;
-      padding: 0 0 3rem;
+    footer { color: rgba(238, 244, 237, 0.55); text-align: center; padding: 0 0 3rem; }
+
+    @keyframes floatIn { from { opacity: 0; transform: translateY(28px) scale(0.98); } to { opacity: 1; transform: translateY(0) scale(1); } }
+    @keyframes shimmer { 0%, 45% { transform: translateX(-65%); opacity: 0; } 70% { opacity: 1; } 100% { transform: translateX(70%); opacity: 0; } }
+    @keyframes glassDrift { 0%, 100% { translate: 0 0; } 50% { translate: 0 -8px; } }
+    @keyframes portraitFloat { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-10px); } }
+    @keyframes pulseLine { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
+    @keyframes ambientRefraction { from { transform: translate3d(-2%, -1%, 0); } to { transform: translate3d(2%, 1%, 0); } }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; transition-duration: 0.01ms !important; }
     }
 
     @media (max-width: 820px) {
-      header {
-        align-items: flex-start;
-        flex-direction: column;
-      }
-
-      nav {
-        justify-content: flex-start;
-      }
-
-      .team-grid {
-        grid-template-columns: 1fr;
-      }
+      header { align-items: flex-start; flex-direction: column; }
+      nav { justify-content: flex-start; }
+      .org-branch { grid-template-columns: 1fr; }
+      .org-branch::before { left: 50%; right: auto; width: 2px; height: 1.5rem; top: -1.75rem; }
+      .team-card.featured { width: 100%; }
     }
   </style>
 </head>
@@ -285,8 +367,27 @@
         <p>Horizon Synergy is led by a focused startup team shaping products, games, and digital experiences with a hands-on approach to strategy, technology, and execution.</p>
       </section>
 
-      <section class="team-grid" aria-label="Horizon Synergy leadership cards">
-        <article class="team-card">
+      <section class="org-chart" aria-label="Horizon Synergy organisational chart">
+        <div class="org-tier executive" aria-label="Executive leadership">
+          <article class="team-card featured">
+          <div class="portrait-wrap">
+            <img src="../images/neo.jpeg" alt="Neo Stanley Modiba">
+          </div>
+          <div class="card-body">
+            <span class="role">CEO / President</span>
+            <h2>Neo Stanley <span class="gradient-text">Modiba</span></h2>
+            <p>Neo Stanley Modiba leads Horizon Synergy's company vision, operations, and product direction as CEO and President. He helps keep the startup aligned around meaningful products, strong execution, and long-term growth.</p>
+            <ul class="focus-list" aria-label="CEO and President focus areas">
+              <li>Company vision, leadership, and strategic planning</li>
+              <li>Product priorities, partnerships, and business development</li>
+              <li>Team alignment, operations, and growth opportunities</li>
+            </ul>
+          </div>
+          </article>
+        </div>
+
+        <div class="org-branch" aria-label="Product and technology leadership">
+          <article class="team-card">
           <div class="portrait-wrap">
             <img src="../images/njabulo.jpeg" alt="Njabulo Cedric Mnisi (Cedric Arts)">
           </div>
@@ -306,23 +407,8 @@
               <a href="https://www.linkedin.com/in/njabulo-cedric-mnisi/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
             </div>
           </div>
-        </article>
-
-        <article class="team-card">
-          <div class="portrait-wrap">
-            <img src="../images/neo.jpeg" alt="Neo Stanley Modiba">
-          </div>
-          <div class="card-body">
-            <span class="role">CEO / President</span>
-            <h2>Neo Stanley <span class="gradient-text">Modiba</span></h2>
-            <p>Neo Stanley Modiba leads Horizon Synergy's company vision, operations, and product direction as CEO and President. He helps keep the startup aligned around meaningful products, strong execution, and long-term growth.</p>
-            <ul class="focus-list" aria-label="CEO and President focus areas">
-              <li>Company vision, leadership, and strategic planning</li>
-              <li>Product priorities, partnerships, and business development</li>
-              <li>Team alignment, operations, and growth opportunities</li>
-            </ul>
-          </div>
-        </article>
+          </article>
+        </div>
       </section>
     </main>
 
@@ -330,5 +416,11 @@
       <p>&copy; 2025 - 2026 Horizon Synergy. Creations Of Tomorrow.</p>
     </footer>
   </div>
+  <script>
+    document.addEventListener("pointermove", (event) => {
+      document.body.style.setProperty("--mx", `${event.clientX}px`);
+      document.body.style.setProperty("--my", `${event.clientY}px`);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Modernise the team page into an organisational chart with a liquid-glass visual style and subtle motion to better communicate hierarchy and brand aesthetic.
- Provide pointer-reactive refraction and accessible reduced-motion handling so the effect is dynamic but respectful of user preferences.

### Description
- Reworked `team/index.html` markup so the previous `.team-grid` is now an `.org-chart` with an executive tier (CEO/President) above a product/technology branch (CTO). 
- Replaced/adjusted portrait placement so the CEO card is featured in the executive tier and the CTO sits in the branch below.
- Added glassmorphism CSS: new variables (`--glass-edge`, `--glass-shadow`), blurred translucent card backgrounds, refractive highlights, glow connector lines, shimmer and float keyframe animations, and reduced-motion support.
- Added a small script that updates CSS variables on `pointermove` to make the background refraction follow the pointer for a liquid-glass effect.

### Testing
- Ran `git diff --check` and fixed reported issues (no remaining whitespace errors), which completed successfully.
- Parsed the updated HTML with Python's `HTMLParser` via `python3 - <<'PY' ... HTMLParser().feed(...) ... PY` to ensure well-formed markup, which succeeded.
- Launched a simple HTTP server with `python3 -m http.server 8000` and requested `/team/`, which returned `200` confirming the page serves correctly.
- Attempted an automated Playwright screenshot, but it failed because the environment does not have the `playwright` package installed (test failed for missing dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a868b075c832c94259320a300dea6)